### PR TITLE
Add eyes_fix to fix player looking direction

### DIFF
--- a/lua/autorun/client/fix_eyes.lua
+++ b/lua/autorun/client/fix_eyes.lua
@@ -1,0 +1,8 @@
+local eyes_fix = CreateClientConVar("eyes_fix", "1", true, false, "Toggle eye-fix: make other players look at you correctly")
+
+hook.Add("PrePlayerDraw", "fix_them_eyeballs", function(ply)
+    if not eyes_fix:GetBool() then return end
+    if ply ~= LocalPlayer() then
+        ply:SetEyeTarget(LocalPlayer():EyePos())
+    end
+end)


### PR DESCRIPTION
PR fixes the direction that other players are looking at with their eyes, adds a toggle `eyes_fix` to toggle it.

<img width="1203" height="760" alt="image" src="https://github.com/user-attachments/assets/c2d1b80d-26ac-4eb8-93c0-9d6463901d51" />
